### PR TITLE
Choria broker weak ciphers

### DIFF
--- a/network.go
+++ b/network.go
@@ -181,6 +181,19 @@ func (s *Server) setupTLS() (err error) {
 		return err
 	}
 
+	tlsc.CipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	}
+
+	tlsc.PreferServerCipherSuites = true
+	tlsc.MinVersion = tls.VersionTLS12
+	tlsc.CurvePreferences = []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256}
+
 	s.opts.TLSConfig = tlsc
 
 	return


### PR DESCRIPTION
The "64-bit block cipher 3DES" is vulnerable to SWEET32 attack.

Disable non-weak ciphers, and set the minimum TLS level to 1.2 (1.1 is
    getting depreciated soon due to sha1)